### PR TITLE
Debug index: resolve tasks to their results, a partition builder

### DIFF
--- a/org.spoofax.meta.runtime.libraries/analysis/debug.str
+++ b/org.spoofax.meta.runtime.libraries/analysis/debug.str
@@ -62,6 +62,7 @@ rules // Index
     (_, _, _, path, project-path) -> (filename, result)
     with
       index-setup(|language, project-path);
+      task-setup(|project-path);
     	partition  := $[[project-path]/[path]];
       result-ast := [((partition, []), <index-get-all-in-partition> partition)];
       result-ast' := <beautify-indices> result-ast;


### PR DESCRIPTION
Added a partition builder next to the project builder for debugging the index with resolved tasks.
