### PR TITLE
properties view: pretty printer fix

### DIFF
--- a/org.spoofax.meta.runtime.libraries/editor/properties.str
+++ b/org.spoofax.meta.runtime.libraries/editor/properties.str
@@ -28,7 +28,7 @@ rules	// Properties
 			[
 				[
 					("Target",			<target-prop(language-pp)>t),
-					("Constructor",	<cons-prop>t),
+					("Target Constructor",<cons-prop>t),
 				 	("Name",				<name-prop>t),
 				 	("Defines",			<def-prop>t),
 				 	("Refers to",		<ref-prop>t)
@@ -106,7 +106,7 @@ rules // helper rules: filtering
 	
 rules // helper rules: formatting
 	
-	pp-ast(language-pp) = topdown(try(rm-annotations));language-pp;box2text-string(|80)
+	pp-ast(language-pp) = topdown(try(rm-annotations));language-pp
 	
 	pp-cons: t -> $[[<get-constructor> t]/[<get-arguments;length> t]]
 	


### PR DESCRIPTION
properties view: now expects a pretty printer which prints to string instead of to box

renamed "Constructor" to "Target Constructor" to clarify that this is the same as the "Target"
