### PR TITLE
HTML escaped property values in hover tooltip.

### DIFF
--- a/org.spoofax.meta.runtime.libraries/editor/properties.str
+++ b/org.spoofax.meta.runtime.libraries/editor/properties.str
@@ -130,4 +130,9 @@ rules // helper rules: format to HTML for hover
 	property-to-html: (name, prop) -> $[<b>[name]</b>: [<property-to-html>prop]]
 	property-to-html: list -> $[<div>[<properties-to-html>list]</div>]
 		where is-list
-	property-to-html: prop -> prop
+	property-to-html: prop -> <escape-for-html> $[[prop]]
+
+	escape-for-html =
+		string-replace(|"&", "&amp;") ;
+		string-replace(|"<", "&lt;") ;
+		string-replace(|">", "&gt;")


### PR DESCRIPTION
Fixes [Spoofax#871](http://yellowgrass.org/issue/Spoofax/871) for the NaBL properties tooltip.
